### PR TITLE
feat(action): add optional input `checkout`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,10 +3,10 @@ on: [push, pull_request]
 
 jobs:
   test:
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout repository
@@ -16,6 +16,11 @@ jobs:
 
       - name: Run action
         uses: ./
+
+      - name: Run action with checkout
+        uses: ./
+        with:
+          checkout: true
 
       - name: Run action with input `config`
         uses: ./

--- a/README.md
+++ b/README.md
@@ -18,25 +18,44 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: Commitlint
         uses: remarkablemark/commitlint@v1
+        with:
+          checkout: true
 ```
 
 ## Usage
 
-See [action.yml](action.yml)
-
-**Basic:**
+Validate last commit message or all commit messages in a pull request:
 
 ```yaml
 - uses: remarkablemark/commitlint@v1
+  with:
+    checkout: true
 ```
 
+See [action.yml](action.yml)
+
 ## Inputs
+
+### `checkout`
+
+**Optional**: Whether to checkout the repository:
+
+```yaml
+- uses: remarkablemark/commitlint@v1
+  with:
+    checkout: true
+```
+
+Omit this input if the repository has already been checked out with all of the history:
+
+```yaml
+- uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+- uses: remarkablemark/commitlint@v1
+```
 
 ### `config`
 
@@ -65,7 +84,7 @@ See [action.yml](action.yml)
 ```yaml
 - uses: remarkablemark/commitlint@v1
   with:
-    version: 19.6.0
+    version: 19.8.0
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -3,21 +3,35 @@ description: Lint commit messages with GitHub Actions.
 author: remarkablemark
 
 inputs:
+  checkout:
+    description: Whether to checkout the repository
+    required: false
+    default: false
+
   config:
     description: Config to enforce conventional commits
+    required: false
     default: '@commitlint/config-conventional'
 
   from:
     description: Lower end of the commit range to lint
+    required: false
     default: HEAD~1
 
   version:
     description: Version of @commitlint/cli
+    required: false
     default: latest
 
 runs:
   using: composite
   steps:
+    - name: Checkout repository
+      if: inputs.checkout == 'true'
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
     - name: Install commitlint
       shell: bash
       run: |


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(action): add optional input `checkout`

## What is the current behavior?

You need to add checkout step with fetch-depth set to 0 before running commitlint action:

```yaml
- uses: actions/checkout@v4
  with:
    fetch-depth: 0
- uses: remarkablemark/commitlint@v1
```

## What is the new behavior?

Action will checkout all history with input:

```yaml
- uses: remarkablemark/commitlint@v1
  with:
    checkout: true
```

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation