### PR TITLE
fix(action): pin commitlint version to 19.8.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run action with input `version`
         uses: ./
         with:
-          version: 19.6.0
+          version: 19.8.1
 
       - name: Create `package.json` and `.commitlintrc.json`
         shell: bash

--- a/README.md
+++ b/README.md
@@ -79,12 +79,12 @@ Omit this input if the repository has already been checked out with all of the h
 
 ### `version`
 
-**Optional**: The version of [`@commitlint/cli`](https://www.npmjs.com/package/@commitlint/cli). Defaults to `latest`:
+**Optional**: The version of [`@commitlint/cli`](https://www.npmjs.com/package/@commitlint/cli). Defaults to `19.8.1`:
 
 ```yaml
 - uses: remarkablemark/commitlint@v2
   with:
-    version: 19.8.0
+    version: 19.8.1
 ```
 
 ## License

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ inputs:
   version:
     description: Version of @commitlint/cli
     required: false
-    default: latest
+    default: 19.8.1
 
 runs:
   using: composite


### PR DESCRIPTION
## Summary

- Pin the action's default commitlint version to [19.8.1](https://github.com/conventional-changelog/commitlint/releases/tag/v19.8.1)
- Update the README example to match the pinned default
- Align the workflow coverage with the same explicit version

## Testing

- [ ] CI passes
