### PR TITLE
fix(action): pin tinyexec to 1.0.2

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,8 @@ runs:
     - name: Install commitlint
       shell: bash
       run: |
-        npm install --silent --global commitlint@${{ toJSON(inputs.version) }}
+        # https://github.com/tinylibs/tinyexec/issues/90
+        npm install --silent --global commitlint@${{ toJSON(inputs.version) }} tinyexec@1.0.2
 
         if [[ '${{ runner.debug }}' == 1 ]]; then
           commitlint --version


### PR DESCRIPTION
## What is the motivation for this pull request?

Fix commitlint error

- https://github.com/conventional-changelog/commitlint/issues/4657
- https://github.com/tinylibs/tinyexec/issues/90

## What is the current behavior?

https://github.com/remarkablemark/commitlint/actions/runs/23063370495/job/66995484576?pr=14

```
Run npm install --silent --global commitlint@"20.4.4"
Run if [[ -f package.json ]] && grep --quiet '"@commitlint/' package.json; then
node:internal/modules/esm/resolve:283
    throw new ERR_MODULE_NOT_FOUND(
          ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/usr/local/lib/node_modules/commitlint/node_modules/tinyexec/dist/main.js' imported from /usr/local/lib/node_modules/commitlint/node_modules/@commitlint/cli/lib/cli.js
    at finalizeResolution (node:internal/modules/esm/resolve:283:11)
    at moduleResolve (node:internal/modules/esm/resolve:952:10)
    at defaultResolve (node:internal/modules/esm/resolve:1188:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:708:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:657:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:640:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:264:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:168:49) {
  code: 'ERR_MODULE_NOT_FOUND',
  url: 'file:///usr/local/lib/node_modules/commitlint/node_modules/tinyexec/dist/main.js'
}

Node.js v20.20.0
```

## What is the new behavior?

Pin tinyexec to 1.0.2

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation